### PR TITLE
Add metrics endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,10 +6,15 @@ import json
 import os
 import requests
 from flask import Flask, request, render_template, send_file
+from prometheus_flask_exporter import PrometheusMetrics
 
+# Main Flask app
 app = Flask(__name__)
 
 url = os.getenv('LITURGICAL_API_URL', default='https://liturgical-api.gazeley.uk')
+
+# Initialize metrics without an app (or with None)
+metrics = PrometheusMetrics(app)
 
 @app.route('/', methods =["GET", "POST"])
 def main():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask >= 3.0.0
 requests >= 2.32.0
+prometheus-flask-exporter==0.23.2


### PR DESCRIPTION
Adds a metrics endpoint at `/metrics`. This is unauthenticated, so it should be protected by the reverse proxy or ingress controller.

Fixes #20 